### PR TITLE
04 UI Cleanup

### DIFF
--- a/taylor.xcodeproj/project.pbxproj
+++ b/taylor.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		007C48652410BC5C004C2C02 /* AlbumDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007C48642410BC5C004C2C02 /* AlbumDetailView.swift */; };
 		007C487D24119B7A004C2C02 /* Album.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007C487C24119B7A004C2C02 /* Album.swift */; };
 		007C488024119D7C004C2C02 /* DataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007C487F24119D7C004C2C02 /* DataService.swift */; };
+		00BFA85624B13D3E0083D3BB /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BFA85524B13D3E0083D3BB /* SafariView.swift */; };
 		00EAAB9C2414A79300B59C4E /* ItunesAlbum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00EAAB9B2414A79300B59C4E /* ItunesAlbum.swift */; };
 		00EEEC1524AFCB48009CA61E /* ImageUrlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00EEEC1424AFCB48009CA61E /* ImageUrlView.swift */; };
 		00EEEC1724AFCB87009CA61E /* RemoteImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00EEEC1624AFCB87009CA61E /* RemoteImage.swift */; };
@@ -60,6 +61,7 @@
 		007C48642410BC5C004C2C02 /* AlbumDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumDetailView.swift; sourceTree = "<group>"; };
 		007C487C24119B7A004C2C02 /* Album.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Album.swift; sourceTree = "<group>"; };
 		007C487F24119D7C004C2C02 /* DataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataService.swift; sourceTree = "<group>"; };
+		00BFA85524B13D3E0083D3BB /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
 		00EAAB9B2414A79300B59C4E /* ItunesAlbum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItunesAlbum.swift; sourceTree = "<group>"; };
 		00EEEC1424AFCB48009CA61E /* ImageUrlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUrlView.swift; sourceTree = "<group>"; };
 		00EEEC1624AFCB87009CA61E /* RemoteImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImage.swift; sourceTree = "<group>"; };
@@ -194,6 +196,7 @@
 			isa = PBXGroup;
 			children = (
 				00EEEC1424AFCB48009CA61E /* ImageUrlView.swift */,
+				00BFA85524B13D3E0083D3BB /* SafariView.swift */,
 			);
 			path = "UI Components";
 			sourceTree = "<group>";
@@ -221,6 +224,8 @@
 			dependencies = (
 			);
 			name = taylor;
+			packageProductDependencies = (
+			);
 			productName = taylor;
 			productReference = 007C48312410B55D004C2C02 /* taylor.app */;
 			productType = "com.apple.product-type.application";
@@ -293,6 +298,8 @@
 				Base,
 			);
 			mainGroup = 007C48282410B55D004C2C02;
+			packageReferences = (
+			);
 			productRefGroup = 007C48322410B55D004C2C02 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -337,6 +344,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				007C48352410B55D004C2C02 /* AppDelegate.swift in Sources */,
+				00BFA85624B13D3E0083D3BB /* SafariView.swift in Sources */,
 				007C48652410BC5C004C2C02 /* AlbumDetailView.swift in Sources */,
 				00EEEC1524AFCB48009CA61E /* ImageUrlView.swift in Sources */,
 				00EEEC1724AFCB87009CA61E /* RemoteImage.swift in Sources */,

--- a/taylor.xcodeproj/project.pbxproj
+++ b/taylor.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		007C487D24119B7A004C2C02 /* Album.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007C487C24119B7A004C2C02 /* Album.swift */; };
 		007C488024119D7C004C2C02 /* DataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007C487F24119D7C004C2C02 /* DataService.swift */; };
 		00BFA85624B13D3E0083D3BB /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BFA85524B13D3E0083D3BB /* SafariView.swift */; };
+		00BFA85B24B18A470083D3BB /* AlbumDetailHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BFA85A24B18A470083D3BB /* AlbumDetailHeaderView.swift */; };
 		00EAAB9C2414A79300B59C4E /* ItunesAlbum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00EAAB9B2414A79300B59C4E /* ItunesAlbum.swift */; };
 		00EEEC1524AFCB48009CA61E /* ImageUrlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00EEEC1424AFCB48009CA61E /* ImageUrlView.swift */; };
 		00EEEC1724AFCB87009CA61E /* RemoteImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00EEEC1624AFCB87009CA61E /* RemoteImage.swift */; };
@@ -62,6 +63,7 @@
 		007C487C24119B7A004C2C02 /* Album.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Album.swift; sourceTree = "<group>"; };
 		007C487F24119D7C004C2C02 /* DataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataService.swift; sourceTree = "<group>"; };
 		00BFA85524B13D3E0083D3BB /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
+		00BFA85A24B18A470083D3BB /* AlbumDetailHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumDetailHeaderView.swift; sourceTree = "<group>"; };
 		00EAAB9B2414A79300B59C4E /* ItunesAlbum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItunesAlbum.swift; sourceTree = "<group>"; };
 		00EEEC1424AFCB48009CA61E /* ImageUrlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUrlView.swift; sourceTree = "<group>"; };
 		00EEEC1624AFCB87009CA61E /* RemoteImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImage.swift; sourceTree = "<group>"; };
@@ -162,6 +164,7 @@
 			children = (
 				007C48382410B55D004C2C02 /* AlbumListView.swift */,
 				007C48642410BC5C004C2C02 /* AlbumDetailView.swift */,
+				00BFA85A24B18A470083D3BB /* AlbumDetailHeaderView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -353,6 +356,7 @@
 				007C488024119D7C004C2C02 /* DataService.swift in Sources */,
 				007C48392410B55D004C2C02 /* AlbumListView.swift in Sources */,
 				00EAAB9C2414A79300B59C4E /* ItunesAlbum.swift in Sources */,
+				00BFA85B24B18A470083D3BB /* AlbumDetailHeaderView.swift in Sources */,
 				007C487D24119B7A004C2C02 /* Album.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/taylor/Model/ItunesAlbum.swift
+++ b/taylor/Model/ItunesAlbum.swift
@@ -14,6 +14,7 @@ struct ItunesAlbum: Codable {
     var collectionName: String?
     var artistName: String?
     var artistViewUrl: String?
+    var collectionViewUrl: String?
     var artworkUrl60: String?
     var artworkUrl100: String?
     var releaseDate: Date?

--- a/taylor/UI Components/ImageUrlView.swift
+++ b/taylor/UI Components/ImageUrlView.swift
@@ -11,7 +11,7 @@ import UIKit
 
 struct ImageUrlView: View {
     @ObservedObject var remoteImageModel: RemoteImage
-    static let blankImage = Image(systemName: "slowmo").resizable()
+    static let blankImage = Image(systemName: "slowmo")
 
     init(url: String?, defaultImage: UIImage?) {
         remoteImageModel = RemoteImage(imageUrl: url, defaultImage: defaultImage)

--- a/taylor/UI Components/SafariView.swift
+++ b/taylor/UI Components/SafariView.swift
@@ -1,0 +1,31 @@
+//
+//  SafariView.swift
+//  taylor
+//
+//  Created by lsease on 7/4/20.
+//  Copyright © 2020 iParty Mobile. All rights reserved.
+//
+import SwiftUI
+import SafariServices
+
+struct SafariView: UIViewControllerRepresentable {
+    typealias UIViewControllerType = SFSafariViewController
+
+    var url: URL?
+
+    func makeUIViewController(context: UIViewControllerRepresentableContext<SafariView>) -> SFSafariViewController {
+        
+        return SFSafariViewController(url: url!)
+    }
+
+    func updateUIViewController(_ safariViewController: SFSafariViewController, context: UIViewControllerRepresentableContext<SafariView>) {
+    }
+}
+
+#if DEBUG
+struct SafariView_Previews: PreviewProvider {
+    static var previews: some View {
+        SafariView(url: URL(string: "https://taylorswift.com")!)
+    }
+}
+#endif

--- a/taylor/ViewModels/Album.swift
+++ b/taylor/ViewModels/Album.swift
@@ -14,6 +14,7 @@ struct Album: Identifiable {
     var name: String
     var externalImageUrl: String?
     var date: Date?
+    var externalLink: String?
     
     init?(itunesAlbum: ItunesAlbum) {
         guard itunesAlbum.collectionType == "Album",
@@ -25,6 +26,7 @@ struct Album: Identifiable {
         self.name = name.capitalized
         self.date = itunesAlbum.releaseDate
         self.externalImageUrl = itunesAlbum.artworkUrl100
+        self.externalLink = itunesAlbum.collectionViewUrl
 
         if let collectionId = itunesAlbum.collectionId {
             self.id = "\(collectionId)"
@@ -47,6 +49,10 @@ struct Album: Identifiable {
         let dateFormatter = DateFormatter()
         dateFormatter.dateStyle = .medium
         return dateFormatter.string(from: date)
+    }
+    
+    var externalImageUrlEnlarged: String? {
+        externalImageUrl?.replacingOccurrences(of: "100x100", with: "1000x1000")
     }
 }
 

--- a/taylor/ViewModels/Album.swift
+++ b/taylor/ViewModels/Album.swift
@@ -33,10 +33,11 @@ struct Album: Identifiable {
         }
     }
     
-    init(name: String, externalImageUrl: String? = nil, date: Date? = nil) {
+    init(name: String, externalImageUrl: String? = nil, date: Date? = nil, externalLink: String? = nil) {
         self.name = name
         self.externalImageUrl = externalImageUrl
         self.date = date
+        self.externalLink = externalLink
     }
     
     var imageName: String {

--- a/taylor/Views/AlbumDetailHeaderView.swift
+++ b/taylor/Views/AlbumDetailHeaderView.swift
@@ -1,0 +1,64 @@
+//
+//  AlbumDetailHeaderView.swift
+//  taylor
+//
+//  Created by lsease on 7/5/20.
+//  Copyright © 2020 iParty Mobile. All rights reserved.
+//
+
+import SwiftUI
+
+struct AlbumDetailHeaderView: View {
+    
+    @Binding var album: Album
+    @State var showSafari = false
+    
+    var body: some View {
+        VStack() {
+            HStack(alignment: .center){
+                Spacer()
+                VStack {
+                    Text(album.name)
+                        .font(.callout)
+                        .padding(6)
+                    
+                    if album.dateString != nil {
+                        Text(album.dateString!)
+                            .font(.callout)
+                            .padding(6)
+                    }
+                    
+                    if self.album.externalLink != nil {
+                        Button(action: {
+                            self.showSafari = true
+                        }) {
+                            Text("See More  >")
+                                .foregroundColor(.yellow)
+                        }
+                        // summon the Safari sheet
+                        .sheet(isPresented: $showSafari) {
+                            SafariView(url:URL(string: self.album.externalLink!)!)
+                        }
+                    }
+                }
+                Spacer()
+            }.background(Color.black)
+            .opacity(0.8)
+            .cornerRadius(10.0)
+            .padding(6)
+            .foregroundColor(.white)
+            
+             Spacer()
+        }
+    }
+}
+
+struct AlbumDetailHeaderView_Previews: PreviewProvider {
+    
+    @State static var album = Album(name: "Fearless", date: Date(), externalLink: "https://google.com")
+    
+    static var previews: some View {
+        
+        return AlbumDetailHeaderView(album: AlbumDetailHeaderView_Previews.$album)
+    }
+}

--- a/taylor/Views/AlbumDetailView.swift
+++ b/taylor/Views/AlbumDetailView.swift
@@ -26,42 +26,7 @@ struct AlbumDetailView: View {
             ImageUrlView(url: album.externalImageUrlEnlarged, defaultImage: nil)
                 .aspectRatio(contentMode: .fit)
 
-            VStack() {
-                HStack(alignment: .center){
-                    Spacer()
-                    VStack {
-                        Text(album.name)
-                            .font(.callout)
-                            .padding(6)
-                        
-                        if album.dateString != nil {
-                            Text(album.dateString!)
-                                .font(.callout)
-                                .padding(6)
-                        }
-                        
-                        if self.album.externalLink != nil {
-                            Button(action: {
-                                self.showSafari = true
-                            }) {
-                                Text("See More  >")
-                                    .foregroundColor(.yellow)
-                            }
-                            // summon the Safari sheet
-                            .sheet(isPresented: $showSafari) {
-                                SafariView(url:URL(string: self.album.externalLink!)!)
-                            }
-                        }
-                    }
-                    Spacer()
-                }.background(Color.black)
-                .opacity(0.8)
-                .cornerRadius(10.0)
-                .padding(6)
-                .foregroundColor(.white)
-                
-                Spacer()
-            }
+            AlbumDetailHeaderView(album: $album)
         }
         
     }

--- a/taylor/Views/AlbumDetailView.swift
+++ b/taylor/Views/AlbumDetailView.swift
@@ -7,10 +7,12 @@
 //
 
 import SwiftUI
+import SafariServices
 
 struct AlbumDetailView: View {
     
     @State var album: Album
+    @State var showSafari = false
     
     var body: some View {
         ZStack(alignment: .center) {
@@ -18,10 +20,10 @@ struct AlbumDetailView: View {
                 .resizable()
                 .scaledToFill()
                 .edgesIgnoringSafeArea(.all)
-                .blur(radius: 30)
-                .opacity(0.7)
+                .blur(radius: 20)
+                .opacity(0.8)
             
-            ImageUrlView(url: album.externalImageUrl, defaultImage: UIImage(named: "cat"))
+            ImageUrlView(url: album.externalImageUrlEnlarged, defaultImage: nil)
                 .aspectRatio(contentMode: .fit)
 
             VStack() {
@@ -36,6 +38,19 @@ struct AlbumDetailView: View {
                             Text(album.dateString!)
                                 .font(.callout)
                                 .padding(6)
+                        }
+                        
+                        if self.album.externalLink != nil {
+                            Button(action: {
+                                self.showSafari = true
+                            }) {
+                                Text("See More  >")
+                                    .foregroundColor(.yellow)
+                            }
+                            // summon the Safari sheet
+                            .sheet(isPresented: $showSafari) {
+                                SafariView(url:URL(string: self.album.externalLink!)!)
+                            }
                         }
                     }
                     Spacer()

--- a/taylor/Views/AlbumListView.swift
+++ b/taylor/Views/AlbumListView.swift
@@ -14,9 +14,18 @@ struct AlbumListView: View {
     
     var body: some View {
         NavigationView {
+            
             List(dataService.albums) { album in
                 NavigationLink(destination: AlbumDetailView(album: album) ) {
-                    Text(album.name)
+                    HStack {
+                        ImageUrlView(url: album.externalImageUrl, defaultImage: nil)
+                        .aspectRatio(contentMode: .fit)
+                            .frame(width: 60, height: 60)
+                            .cornerRadius(30)
+                        
+                        Text(album.name)
+                    }
+                    
                 }
             }
         }

--- a/taylor/Views/AlbumListView.swift
+++ b/taylor/Views/AlbumListView.swift
@@ -13,24 +13,25 @@ struct AlbumListView: View {
     @ObservedObject private var dataService = DataService.shared
     
     var body: some View {
-        NavigationView {
-            
-            List(dataService.albums) { album in
-                NavigationLink(destination: AlbumDetailView(album: album) ) {
-                    HStack {
-                        ImageUrlView(url: album.externalImageUrl, defaultImage: nil)
-                        .aspectRatio(contentMode: .fit)
+        VStack {
+            NavigationView {
+                List(dataService.albums) { album in
+                    NavigationLink(destination: AlbumDetailView(album: album) ) {
+                        HStack {
+                            ImageUrlView(url: album.externalImageUrl, defaultImage: nil)
+                            .aspectRatio(contentMode: .fit)
                             .frame(width: 60, height: 60)
                             .cornerRadius(30)
+                            
+                            Text(album.name)
+                        }
                         
-                        Text(album.name)
                     }
-                    
                 }
             }
-        }
-        .onAppear() {
-            DataService.shared.loadAlbums()
+            .onAppear() {
+                DataService.shared.loadAlbums()
+            }
         }
     }
 }


### PR DESCRIPTION
This PR cleans up our UI a bit, adds some refactor and a bit more detail.
Specifically, we:
- add a link to the apple music store URL from the detail page,
- refactor the detail header out to its own view, 
- improve the sizing of the images on the detail page
- add a thumbnail icon to the list view. 

<img src="https://user-images.githubusercontent.com/1085547/86537317-4ccf3b00-bebc-11ea-85a3-1bd2ea0174d9.png" data-canonical-src="https://user-images.githubusercontent.com/1085547/86537317-4ccf3b00-bebc-11ea-85a3-1bd2ea0174d9.png" width="300"/> <img src="https://user-images.githubusercontent.com/1085547/86537321-5062c200-bebc-11ea-88f0-d50530519c69.png" data-canonical-src="https://user-images.githubusercontent.com/1085547/86537321-5062c200-bebc-11ea-88f0-d50530519c69.png" width="300"/>

